### PR TITLE
Home Assistant 2021.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 🚧 In development, but you can copy `sensor.py` down to your HASS install: just copy-paste `sensor.py` into a file name the same inside your HASS `custom_components/bchydro` directory. Edit `bchydro_username` and `bchydro_password` to match your BCHydro account.
 
-## This fork fixes issue with the manifest
+## This fork fixes an issue with the manifest
 
 core-2021.6 required some changes. Currently it is working with core-2022.2.9
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 🚧 In development, but you can copy `sensor.py` down to your HASS install: just copy-paste `sensor.py` into a file name the same inside your HASS `custom_components/bchydro` directory. Edit `bchydro_username` and `bchydro_password` to match your BCHydro account.
 
+## This fork fixes issue with the manifest
+
+core-2021.6 required some changes. Currently it is working with core-2022.2.9
+
 ## Installation
 
 Place these files inside a directory in your custom_components directory:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# NOTE:
+
+2022/03/08 - Recently I am receiving 401 Unauthorized, but this could be related to my account. I will update this note as soon as I had the time to investigate it further.
+
 # Home Assistant BCHydro Sensor
 
 🚧 In development, but you can copy `sensor.py` down to your HASS install: just copy-paste `sensor.py` into a file name the same inside your HASS `custom_components/bchydro` directory. Edit `bchydro_username` and `bchydro_password` to match your BCHydro account.

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,14 @@
 {
+  "version": "0.1.0",
   "domain": "bchydro",
   "name": "BC Hydro",
-  "documentation": "https://github.com/emcniece/hass-bchydro",
+  "documentation": "https://github.com/sascha432/hass-bchydro",
   "dependencies": [],
   "codeowners": [],
-  "requirements": []
+  "requirements": [
+    "flake8==4.0.1",
+    "black==22.1.0"
+  ],
+  "iot_class": "cloud_polling",
+  "config_flow": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,10 +5,7 @@
   "documentation": "https://github.com/sascha432/hass-bchydro",
   "dependencies": [],
   "codeowners": [],
-  "requirements": [
-    "flake8==4.0.1",
-    "black==22.1.0"
-  ],
+  "requirements": [],
   "iot_class": "cloud_polling",
   "config_flow": false
 }


### PR DESCRIPTION
## This fork fixes an issue with the manifest

core-2021.6 required some changes. Currently it is working with core-2022.2.9